### PR TITLE
🐛 Convert to check List<int> instead of IEnumerable<int>

### DIFF
--- a/TogglAPI.NetStandard/DataObjects/BaseDataObject.cs
+++ b/TogglAPI.NetStandard/DataObjects/BaseDataObject.cs
@@ -20,7 +20,7 @@ namespace Toggl.DataObjects
 
                              if (jsonProperty == null || val == null) return;
 
-                             var ints = val as IEnumerable<int>;
+                             var ints = val as List<int>;
 
                              if (ints != null)
                              {


### PR DESCRIPTION
Throws an error when trying to send user_ids because `var ints = val as IEnumerable<int>;` will never be satisfied in `BaseDataObject.cs` file. Therefore, it sends out array as `user_ids=System.Collections.Generic.List%601%5BSystem.Int32%5D instead` 
and this throws a 400 bad request error