### PR TITLE
Upgrade TargetFrameworks of projects

### DIFF
--- a/TogglAPI.NetStandard.Tests/TogglAPI.NetStandard.Tests.csproj
+++ b/TogglAPI.NetStandard.Tests/TogglAPI.NetStandard.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TogglAPI.NetStandard/TogglAPI.NetStandard.csproj
+++ b/TogglAPI.NetStandard/TogglAPI.NetStandard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello. Usage of nuget package are showing warning:
"warning NU1701: Package 'TogglAPI.Net 0.2.0' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETCoreApp,Version=v3.1'. This package may not be fully compatible with your project."

Update to netstandard2.1 is fix for this issue. I update also TargetFramework of Tests project.