### PR TITLE
fix: update base urls on v0.2.0

### DIFF
--- a/Toggl/Routes/ApiRoutes.cs
+++ b/Toggl/Routes/ApiRoutes.cs
@@ -7,10 +7,10 @@ namespace Toggl
 {
     public static class ApiRoutes
     {
-	    private const string TogglBaseUrl                           = "https://www.toggl.com/api/v8";
-		private const string TogglReportUrl                         = "https://toggl.com/reports/api/v2";
+        private const string TogglBaseUrl                           = "https://api.track.toggl.com/api/v8";
+        private const string TogglReportUrl                         = "https://api.track.toggl.com/reports/api/v2";
 
-	    public static class Reports
+        public static class Reports
         {
             public static readonly string Detailed                  = TogglReportUrl + "/details";
             public static readonly string Weekly                    = TogglReportUrl + "/weekly";
@@ -57,7 +57,7 @@ namespace Toggl
 
         public static class Project
         {
-			public readonly static string ProjectsBulkDeleteUrl     = TogglBaseUrl + "/projects/{0}";
+            public readonly static string ProjectsBulkDeleteUrl     = TogglBaseUrl + "/projects/{0}";
             public readonly static string ProjectsUrl               = TogglBaseUrl + "/projects";
             public readonly static string DetailUrl                 = TogglBaseUrl + "/projects/{0}";
             public readonly static string UsersUrl                  = TogglBaseUrl + "/projects/{0}/project_users";


### PR DESCRIPTION
update base urls on nuget packege v.0.2.0 (https://www.nuget.org/packages/TogglAPI.Net/)

I created a commit branch 9b889492b06c47f435c33e41fcbe997fb1adc1f4 which is the base of the nuget package.

Note: This is important for people like me who are using the .NET package and not the .NET standard version.